### PR TITLE
Finished all of read (Bitcoin blockchain traversal)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -660,13 +660,24 @@ dependencies = [
 
 [[package]]
 name = "json-patch"
-version = "1.4.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec9ad60d674508f3ca8f380a928cfe7b096bc729c4e2dbfe3852bc45da3ab30b"
+checksum = "159294d661a039f7644cea7e4d844e6b25aaf71c1ffe9d73a96d768c24b0faf4"
 dependencies = [
+ "jsonptr",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "jsonptr"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5a3cc660ba5d72bce0b3bb295bf20847ccbb40fd423f3f05b61273672e561fe"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ onlyerror = "0.1"
 rand = "0.8"
 
 # JSON processing
-json-patch = "1"
+json-patch = "4"
 serde = { version = "1", features = ["derive"] }
 serde_jcs = "0.1"
 serde_json = "1"

--- a/examples/read_did.rs
+++ b/examples/read_did.rs
@@ -1,24 +1,38 @@
 use anyhow::Result;
 use did_btc1::blockchain::TraversalState;
-use did_btc1::{Document, ResolutionOptions};
+use did_btc1::{Document, ResolutionOptions, document::SidecarData};
+use std::collections::HashMap;
 
 fn main() -> Result<()> {
+    // TODO: Need all of the sidecar data to resolve the given DID (because it has updates).
+    let resolution_options = ResolutionOptions {
+        sidecar_data: Some(SidecarData {
+            blockchain_rpc_uri: Some("https://mutinynet.com/api".into()),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
     let agent = ureq::agent();
-    let did = "did:btc1:k1qgp5h79scv4sfqkzak5g6y89dsy3cq0pd2nussu2cm3zjfhn4ekwrucc4q7t7".parse()?;
-    let mut fsm = Document::read(&did, ResolutionOptions::default())?;
+    let did = "did:btc1:k1q5pa5tq86fzrl0ez32nh8e0ks4tzzkxnnmn8tdvxk04ahzt70u09dag02h0cp".parse()?;
+    let mut fsm = Document::read(&did, resolution_options)?;
 
     // Drive the blockchain traversal state machine forward.
     loop {
         match fsm.traverse()? {
             TraversalState::Requests(next_state, requests) => {
-                let responses = requests
-                    .into_iter()
-                    .map(|req| {
+                let mut responses = HashMap::new();
+
+                for (beacon_type, requests) in requests {
+                    for req in requests {
                         let mut resp = agent.run(req)?;
 
-                        Ok(resp.body_mut().read_json()?)
-                    })
-                    .collect::<Result<Vec<_>>>()?;
+                        let transactions: Vec<_> = resp.body_mut().read_json()?;
+
+                        let entry: &mut Vec<_> = responses.entry(beacon_type).or_default();
+                        entry.extend(transactions);
+                    }
+                }
 
                 fsm = next_state.process_responses(responses);
             }

--- a/fixtures/k1q5pa5tq86fzrl0ez32nh8e0ks4tzzkxnnmn8tdvxk04ahzt70u09dag02h0cp-transactions.json
+++ b/fixtures/k1q5pa5tq86fzrl0ez32nh8e0ks4tzzkxnnmn8tdvxk04ahzt70u09dag02h0cp-transactions.json
@@ -1,251 +1,304 @@
-[
-  {
-    "txid": "403e8a168e2e33dda6274021975ce9ea38de72d481cd7674507020ac435890fa",
-    "version": 1,
-    "locktime": 0,
-    "vin": [
-      {
-        "txid": "64d1db7082c5860a4c689f90d59809ab6eb3cad9b36691648c4f1c1ded7ae3e8",
-        "vout": 0,
-        "prevout": {
+{
+  "Singleton": [
+    {
+      "txid": "403e8a168e2e33dda6274021975ce9ea38de72d481cd7674507020ac435890fa",
+      "version": 1,
+      "locktime": 0,
+      "vin": [
+        {
+          "txid": "64d1db7082c5860a4c689f90d59809ab6eb3cad9b36691648c4f1c1ded7ae3e8",
+          "vout": 0,
+          "prevout": {
+            "scriptpubkey": "76a9148aa387fde9e8659457862f49cdcc20b9cc2022d188ac",
+            "scriptpubkey_asm": "OP_DUP OP_HASH160 OP_PUSHBYTES_20 8aa387fde9e8659457862f49cdcc20b9cc2022d1 OP_EQUALVERIFY OP_CHECKSIG",
+            "scriptpubkey_type": "p2pkh",
+            "scriptpubkey_address": "mtA1SshFsJtD2Di1KBSTmyuD23eBqUekQ3",
+            "value": 10000
+          },
+          "scriptsig": "483045022100fc8a5b42b72b0c654e4dd0b3584ffe3237d017de13396d3d37f576259002bff102205293f0faac9368a2555211ee1cca66f99804d5c0486d7a67ee577becf104bfd4012103da2c07d2443fbf228aa773e5f685562158d39ee675b586b3ebdb897e7f1e56f5",
+          "scriptsig_asm": "OP_PUSHBYTES_72 3045022100fc8a5b42b72b0c654e4dd0b3584ffe3237d017de13396d3d37f576259002bff102205293f0faac9368a2555211ee1cca66f99804d5c0486d7a67ee577becf104bfd401 OP_PUSHBYTES_33 03da2c07d2443fbf228aa773e5f685562158d39ee675b586b3ebdb897e7f1e56f5",
+          "is_coinbase": false,
+          "sequence": 4294967295
+        }
+      ],
+      "vout": [
+        {
+          "scriptpubkey": "76a9148aa387fde9e8659457862f49cdcc20b9cc2022d188ac",
+          "scriptpubkey_asm": "OP_DUP OP_HASH160 OP_PUSHBYTES_20 8aa387fde9e8659457862f49cdcc20b9cc2022d1 OP_EQUALVERIFY OP_CHECKSIG",
+          "scriptpubkey_type": "p2pkh",
+          "scriptpubkey_address": "mtA1SshFsJtD2Di1KBSTmyuD23eBqUekQ3",
+          "value": 6000
+        },
+        {
+          "scriptpubkey": "6a208a7118ad435229e0772133bb1c522f962eebad713fddd51bc65f0d973831fb9b",
+          "scriptpubkey_asm": "OP_RETURN OP_PUSHBYTES_32 8a7118ad435229e0772133bb1c522f962eebad713fddd51bc65f0d973831fb9b",
+          "scriptpubkey_type": "op_return",
+          "value": 0
+        }
+      ],
+      "size": 235,
+      "weight": 940,
+      "fee": 4000,
+      "status": {
+        "confirmed": true,
+        "block_height": 2219084,
+        "block_hash": "000000de7cb3ac20c17f594ec68b71a93fb25886b774de2385af585b7ecc0f99",
+        "block_time": 1750770503
+      }
+    },
+    {
+      "txid": "64d1db7082c5860a4c689f90d59809ab6eb3cad9b36691648c4f1c1ded7ae3e8",
+      "version": 1,
+      "locktime": 0,
+      "vin": [
+        {
+          "txid": "76613660e11ea0182e1915ce4baa499cbaf8da77f568cfd2de5b0c9c4e9773a4",
+          "vout": 1,
+          "prevout": {
+            "scriptpubkey": "00149b99110a310460a8cbf428144fd5796b451ef003",
+            "scriptpubkey_asm": "OP_0 OP_PUSHBYTES_20 9b99110a310460a8cbf428144fd5796b451ef003",
+            "scriptpubkey_type": "v0_p2wpkh",
+            "scriptpubkey_address": "tb1qnwv3zz33q3s23jl59q2yl4teddz3auqr2hqhhl",
+            "value": 1000000
+          },
+          "scriptsig": "",
+          "scriptsig_asm": "",
+          "witness": [
+            "304402207678ceeebb3b11b7bd7e96c6000ba0927901933463506ff4f85c878e3461a73e022076158293cab47a3ae86858fb6f92689cb53490691559fe31aafdc45455b4a56b01",
+            "032c7236caed0e065f9b4570deeb5e4e917c9f23cb81d797b06e6348cf2c7dfa1a"
+          ],
+          "is_coinbase": false,
+          "sequence": 4294967295
+        }
+      ],
+      "vout": [
+        {
           "scriptpubkey": "76a9148aa387fde9e8659457862f49cdcc20b9cc2022d188ac",
           "scriptpubkey_asm": "OP_DUP OP_HASH160 OP_PUSHBYTES_20 8aa387fde9e8659457862f49cdcc20b9cc2022d1 OP_EQUALVERIFY OP_CHECKSIG",
           "scriptpubkey_type": "p2pkh",
           "scriptpubkey_address": "mtA1SshFsJtD2Di1KBSTmyuD23eBqUekQ3",
           "value": 10000
         },
-        "scriptsig": "483045022100fc8a5b42b72b0c654e4dd0b3584ffe3237d017de13396d3d37f576259002bff102205293f0faac9368a2555211ee1cca66f99804d5c0486d7a67ee577becf104bfd4012103da2c07d2443fbf228aa773e5f685562158d39ee675b586b3ebdb897e7f1e56f5",
-        "scriptsig_asm": "OP_PUSHBYTES_72 3045022100fc8a5b42b72b0c654e4dd0b3584ffe3237d017de13396d3d37f576259002bff102205293f0faac9368a2555211ee1cca66f99804d5c0486d7a67ee577becf104bfd401 OP_PUSHBYTES_33 03da2c07d2443fbf228aa773e5f685562158d39ee675b586b3ebdb897e7f1e56f5",
-        "is_coinbase": false,
-        "sequence": 4294967295
-      }
-    ],
-    "vout": [
-      {
-        "scriptpubkey": "76a9148aa387fde9e8659457862f49cdcc20b9cc2022d188ac",
-        "scriptpubkey_asm": "OP_DUP OP_HASH160 OP_PUSHBYTES_20 8aa387fde9e8659457862f49cdcc20b9cc2022d1 OP_EQUALVERIFY OP_CHECKSIG",
-        "scriptpubkey_type": "p2pkh",
-        "scriptpubkey_address": "mtA1SshFsJtD2Di1KBSTmyuD23eBqUekQ3",
-        "value": 6000
-      },
-      {
-        "scriptpubkey": "6a208a7118ad435229e0772133bb1c522f962eebad713fddd51bc65f0d973831fb9b",
-        "scriptpubkey_asm": "OP_RETURN OP_PUSHBYTES_32 8a7118ad435229e0772133bb1c522f962eebad713fddd51bc65f0d973831fb9b",
-        "scriptpubkey_type": "op_return",
-        "value": 0
-      }
-    ],
-    "size": 235,
-    "weight": 940,
-    "fee": 4000,
-    "status": {
-      "confirmed": true,
-      "block_height": 2219084,
-      "block_hash": "000000de7cb3ac20c17f594ec68b71a93fb25886b774de2385af585b7ecc0f99",
-      "block_time": 1750770503
-    }
-  },
-  {
-    "txid": "64d1db7082c5860a4c689f90d59809ab6eb3cad9b36691648c4f1c1ded7ae3e8",
-    "version": 1,
-    "locktime": 0,
-    "vin": [
-      {
-        "txid": "76613660e11ea0182e1915ce4baa499cbaf8da77f568cfd2de5b0c9c4e9773a4",
-        "vout": 1,
-        "prevout": {
+        {
           "scriptpubkey": "00149b99110a310460a8cbf428144fd5796b451ef003",
           "scriptpubkey_asm": "OP_0 OP_PUSHBYTES_20 9b99110a310460a8cbf428144fd5796b451ef003",
           "scriptpubkey_type": "v0_p2wpkh",
           "scriptpubkey_address": "tb1qnwv3zz33q3s23jl59q2yl4teddz3auqr2hqhhl",
-          "value": 1000000
+          "value": 986000
+        }
+      ],
+      "size": 225,
+      "weight": 573,
+      "fee": 4000,
+      "status": {
+        "confirmed": true,
+        "block_height": 2205334,
+        "block_hash": "0000029ef2f25aba5500f387c6aa975f0bb000e530ff961a76204ac852bd4f3c",
+        "block_time": 1750344587
+      }
+    },
+    {
+      "txid": "d1fd936f1ddffd5ebf630158d2b92fe07be41f13c2c7ee378baf7dbb0337e14d",
+      "version": 1,
+      "locktime": 0,
+      "vin": [
+        {
+          "txid": "beeab27c9ae46c4ab0915fc7e594f8f50edb56e2ac96bdd13eb5be7001c37b5f",
+          "vout": 0,
+          "prevout": {
+            "scriptpubkey": "00148aa387fde9e8659457862f49cdcc20b9cc2022d1",
+            "scriptpubkey_asm": "OP_0 OP_PUSHBYTES_20 8aa387fde9e8659457862f49cdcc20b9cc2022d1",
+            "scriptpubkey_type": "v0_p2wpkh",
+            "scriptpubkey_address": "tb1q323c0l0fapjeg4ux9ayumnpqh8xzqgk3wg82dy",
+            "value": 10000
+          },
+          "scriptsig": "",
+          "scriptsig_asm": "",
+          "witness": [
+            "30440220246a6795f80de8ff45ec4a38a2308586738c4a3690e33954d29ccc7095f18e690220420c2b73a49e607e36f74f72ef2b7621ad3fd8e6cf2feee57df0d12521582e1301",
+            "03da2c07d2443fbf228aa773e5f685562158d39ee675b586b3ebdb897e7f1e56f5"
+          ],
+          "is_coinbase": false,
+          "sequence": 4294967295
+        }
+      ],
+      "vout": [
+        {
+          "scriptpubkey": "00148aa387fde9e8659457862f49cdcc20b9cc2022d1",
+          "scriptpubkey_asm": "OP_0 OP_PUSHBYTES_20 8aa387fde9e8659457862f49cdcc20b9cc2022d1",
+          "scriptpubkey_type": "v0_p2wpkh",
+          "scriptpubkey_address": "tb1q323c0l0fapjeg4ux9ayumnpqh8xzqgk3wg82dy",
+          "value": 6000
         },
-        "scriptsig": "",
-        "scriptsig_asm": "",
-        "witness": [
-          "304402207678ceeebb3b11b7bd7e96c6000ba0927901933463506ff4f85c878e3461a73e022076158293cab47a3ae86858fb6f92689cb53490691559fe31aafdc45455b4a56b01",
-          "032c7236caed0e065f9b4570deeb5e4e917c9f23cb81d797b06e6348cf2c7dfa1a"
-        ],
-        "is_coinbase": false,
-        "sequence": 4294967295
+        {
+          "scriptpubkey": "6a20523793b4a0ccf98d2d3377b23cd979d5fb9f405684ff288d8494207b37932df9",
+          "scriptpubkey_asm": "OP_RETURN OP_PUSHBYTES_32 523793b4a0ccf98d2d3377b23cd979d5fb9f405684ff288d8494207b37932df9",
+          "scriptpubkey_type": "op_return",
+          "value": 0
+        }
+      ],
+      "size": 234,
+      "weight": 609,
+      "fee": 4000,
+      "status": {
+        "confirmed": true,
+        "block_height": 2207945,
+        "block_hash": "0000014a691693c131e003f49c2a0f4403913422879f9f607ee04942e9e37199",
+        "block_time": 1750425431
       }
-    ],
-    "vout": [
-      {
-        "scriptpubkey": "76a9148aa387fde9e8659457862f49cdcc20b9cc2022d188ac",
-        "scriptpubkey_asm": "OP_DUP OP_HASH160 OP_PUSHBYTES_20 8aa387fde9e8659457862f49cdcc20b9cc2022d1 OP_EQUALVERIFY OP_CHECKSIG",
-        "scriptpubkey_type": "p2pkh",
-        "scriptpubkey_address": "mtA1SshFsJtD2Di1KBSTmyuD23eBqUekQ3",
-        "value": 10000
-      },
-      {
-        "scriptpubkey": "00149b99110a310460a8cbf428144fd5796b451ef003",
-        "scriptpubkey_asm": "OP_0 OP_PUSHBYTES_20 9b99110a310460a8cbf428144fd5796b451ef003",
-        "scriptpubkey_type": "v0_p2wpkh",
-        "scriptpubkey_address": "tb1qnwv3zz33q3s23jl59q2yl4teddz3auqr2hqhhl",
-        "value": 986000
-      }
-    ],
-    "size": 225,
-    "weight": 573,
-    "fee": 4000,
-    "status": {
-      "confirmed": true,
-      "block_height": 2205334,
-      "block_hash": "0000029ef2f25aba5500f387c6aa975f0bb000e530ff961a76204ac852bd4f3c",
-      "block_time": 1750344587
-    }
-  },
-  {
-    "txid": "d1fd936f1ddffd5ebf630158d2b92fe07be41f13c2c7ee378baf7dbb0337e14d",
-    "version": 1,
-    "locktime": 0,
-    "vin": [
-      {
-        "txid": "beeab27c9ae46c4ab0915fc7e594f8f50edb56e2ac96bdd13eb5be7001c37b5f",
-        "vout": 0,
-        "prevout": {
+    },
+    {
+      "txid": "beeab27c9ae46c4ab0915fc7e594f8f50edb56e2ac96bdd13eb5be7001c37b5f",
+      "version": 1,
+      "locktime": 0,
+      "vin": [
+        {
+          "txid": "64d1db7082c5860a4c689f90d59809ab6eb3cad9b36691648c4f1c1ded7ae3e8",
+          "vout": 1,
+          "prevout": {
+            "scriptpubkey": "00149b99110a310460a8cbf428144fd5796b451ef003",
+            "scriptpubkey_asm": "OP_0 OP_PUSHBYTES_20 9b99110a310460a8cbf428144fd5796b451ef003",
+            "scriptpubkey_type": "v0_p2wpkh",
+            "scriptpubkey_address": "tb1qnwv3zz33q3s23jl59q2yl4teddz3auqr2hqhhl",
+            "value": 986000
+          },
+          "scriptsig": "",
+          "scriptsig_asm": "",
+          "witness": [
+            "304402206f530a209259154cd17389a477088148b6d2142145d6b94029fa257453731ec6022045c0f2d20f146780ab1459f453cf4b0eed5ffc4563c731202095ae97493c804401",
+            "032c7236caed0e065f9b4570deeb5e4e917c9f23cb81d797b06e6348cf2c7dfa1a"
+          ],
+          "is_coinbase": false,
+          "sequence": 4294967295
+        }
+      ],
+      "vout": [
+        {
           "scriptpubkey": "00148aa387fde9e8659457862f49cdcc20b9cc2022d1",
           "scriptpubkey_asm": "OP_0 OP_PUSHBYTES_20 8aa387fde9e8659457862f49cdcc20b9cc2022d1",
           "scriptpubkey_type": "v0_p2wpkh",
           "scriptpubkey_address": "tb1q323c0l0fapjeg4ux9ayumnpqh8xzqgk3wg82dy",
           "value": 10000
         },
-        "scriptsig": "",
-        "scriptsig_asm": "",
-        "witness": [
-          "30440220246a6795f80de8ff45ec4a38a2308586738c4a3690e33954d29ccc7095f18e690220420c2b73a49e607e36f74f72ef2b7621ad3fd8e6cf2feee57df0d12521582e1301",
-          "03da2c07d2443fbf228aa773e5f685562158d39ee675b586b3ebdb897e7f1e56f5"
-        ],
-        "is_coinbase": false,
-        "sequence": 4294967295
-      }
-    ],
-    "vout": [
-      {
-        "scriptpubkey": "00148aa387fde9e8659457862f49cdcc20b9cc2022d1",
-        "scriptpubkey_asm": "OP_0 OP_PUSHBYTES_20 8aa387fde9e8659457862f49cdcc20b9cc2022d1",
-        "scriptpubkey_type": "v0_p2wpkh",
-        "scriptpubkey_address": "tb1q323c0l0fapjeg4ux9ayumnpqh8xzqgk3wg82dy",
-        "value": 6000
-      },
-      {
-        "scriptpubkey": "6a20523793b4a0ccf98d2d3377b23cd979d5fb9f405684ff288d8494207b37932df9",
-        "scriptpubkey_asm": "OP_RETURN OP_PUSHBYTES_32 523793b4a0ccf98d2d3377b23cd979d5fb9f405684ff288d8494207b37932df9",
-        "scriptpubkey_type": "op_return",
-        "value": 0
-      }
-    ],
-    "size": 234,
-    "weight": 609,
-    "fee": 4000,
-    "status": {
-      "confirmed": true,
-      "block_height": 2207945,
-      "block_hash": "0000014a691693c131e003f49c2a0f4403913422879f9f607ee04942e9e37199",
-      "block_time": 1750425431
-    }
-  },
-  {
-    "txid": "beeab27c9ae46c4ab0915fc7e594f8f50edb56e2ac96bdd13eb5be7001c37b5f",
-    "version": 1,
-    "locktime": 0,
-    "vin": [
-      {
-        "txid": "64d1db7082c5860a4c689f90d59809ab6eb3cad9b36691648c4f1c1ded7ae3e8",
-        "vout": 1,
-        "prevout": {
-          "scriptpubkey": "00149b99110a310460a8cbf428144fd5796b451ef003",
-          "scriptpubkey_asm": "OP_0 OP_PUSHBYTES_20 9b99110a310460a8cbf428144fd5796b451ef003",
-          "scriptpubkey_type": "v0_p2wpkh",
-          "scriptpubkey_address": "tb1qnwv3zz33q3s23jl59q2yl4teddz3auqr2hqhhl",
-          "value": 986000
-        },
-        "scriptsig": "",
-        "scriptsig_asm": "",
-        "witness": [
-          "304402206f530a209259154cd17389a477088148b6d2142145d6b94029fa257453731ec6022045c0f2d20f146780ab1459f453cf4b0eed5ffc4563c731202095ae97493c804401",
-          "032c7236caed0e065f9b4570deeb5e4e917c9f23cb81d797b06e6348cf2c7dfa1a"
-        ],
-        "is_coinbase": false,
-        "sequence": 4294967295
-      }
-    ],
-    "vout": [
-      {
-        "scriptpubkey": "00148aa387fde9e8659457862f49cdcc20b9cc2022d1",
-        "scriptpubkey_asm": "OP_0 OP_PUSHBYTES_20 8aa387fde9e8659457862f49cdcc20b9cc2022d1",
-        "scriptpubkey_type": "v0_p2wpkh",
-        "scriptpubkey_address": "tb1q323c0l0fapjeg4ux9ayumnpqh8xzqgk3wg82dy",
-        "value": 10000
-      },
-      {
-        "scriptpubkey": "00149b99110a310460a8cbf428144fd5796b451ef003",
-        "scriptpubkey_asm": "OP_0 OP_PUSHBYTES_20 9b99110a310460a8cbf428144fd5796b451ef003",
-        "scriptpubkey_type": "v0_p2wpkh",
-        "scriptpubkey_address": "tb1qnwv3zz33q3s23jl59q2yl4teddz3auqr2hqhhl",
-        "value": 972000
-      }
-    ],
-    "size": 222,
-    "weight": 561,
-    "fee": 4000,
-    "status": {
-      "confirmed": true,
-      "block_height": 2207938,
-      "block_hash": "0000020201b5edad2ce4b384ce3c1e1366311acd62223cdc6af26e3e6f5afb31",
-      "block_time": 1750425212
-    }
-  },
-  {
-    "txid": "83928822546ca24f5ea3fe2e5927758ea1bd4c65028dccfa7ebd704674865584",
-    "version": 1,
-    "locktime": 0,
-    "vin": [
-      {
-        "txid": "beeab27c9ae46c4ab0915fc7e594f8f50edb56e2ac96bdd13eb5be7001c37b5f",
-        "vout": 1,
-        "prevout": {
+        {
           "scriptpubkey": "00149b99110a310460a8cbf428144fd5796b451ef003",
           "scriptpubkey_asm": "OP_0 OP_PUSHBYTES_20 9b99110a310460a8cbf428144fd5796b451ef003",
           "scriptpubkey_type": "v0_p2wpkh",
           "scriptpubkey_address": "tb1qnwv3zz33q3s23jl59q2yl4teddz3auqr2hqhhl",
           "value": 972000
+        }
+      ],
+      "size": 222,
+      "weight": 561,
+      "fee": 4000,
+      "status": {
+        "confirmed": true,
+        "block_height": 2207938,
+        "block_hash": "0000020201b5edad2ce4b384ce3c1e1366311acd62223cdc6af26e3e6f5afb31",
+        "block_time": 1750425212
+      }
+    },
+    {
+      "txid": "83928822546ca24f5ea3fe2e5927758ea1bd4c65028dccfa7ebd704674865584",
+      "version": 1,
+      "locktime": 0,
+      "vin": [
+        {
+          "txid": "beeab27c9ae46c4ab0915fc7e594f8f50edb56e2ac96bdd13eb5be7001c37b5f",
+          "vout": 1,
+          "prevout": {
+            "scriptpubkey": "00149b99110a310460a8cbf428144fd5796b451ef003",
+            "scriptpubkey_asm": "OP_0 OP_PUSHBYTES_20 9b99110a310460a8cbf428144fd5796b451ef003",
+            "scriptpubkey_type": "v0_p2wpkh",
+            "scriptpubkey_address": "tb1qnwv3zz33q3s23jl59q2yl4teddz3auqr2hqhhl",
+            "value": 972000
+          },
+          "scriptsig": "",
+          "scriptsig_asm": "",
+          "witness": [
+            "304402204ac1b5ffd7bebc0f2bfa527262fd22c66d57042e2097fc5e6ed738c2cfcac41602207a4c585a4940e259aa7751f6670f015f7c9f1124a384b7b24a3a1b6fc106f88c01",
+            "032c7236caed0e065f9b4570deeb5e4e917c9f23cb81d797b06e6348cf2c7dfa1a"
+          ],
+          "is_coinbase": false,
+          "sequence": 4294967295
+        }
+      ],
+      "vout": [
+        {
+          "scriptpubkey": "5120ce30776aae6b27a32a6139067032025071f236cd2ae926e5484bee47ef90498d",
+          "scriptpubkey_asm": "OP_PUSHNUM_1 OP_PUSHBYTES_32 ce30776aae6b27a32a6139067032025071f236cd2ae926e5484bee47ef90498d",
+          "scriptpubkey_type": "v1_p2tr",
+          "scriptpubkey_address": "tb1pecc8w64wdvn6x2np8yr8qvsz2pclydkd9t5jde2gf0hy0musfxxsn23q20",
+          "value": 10000
         },
-        "scriptsig": "",
-        "scriptsig_asm": "",
-        "witness": [
-          "304402204ac1b5ffd7bebc0f2bfa527262fd22c66d57042e2097fc5e6ed738c2cfcac41602207a4c585a4940e259aa7751f6670f015f7c9f1124a384b7b24a3a1b6fc106f88c01",
-          "032c7236caed0e065f9b4570deeb5e4e917c9f23cb81d797b06e6348cf2c7dfa1a"
-        ],
-        "is_coinbase": false,
-        "sequence": 4294967295
+        {
+          "scriptpubkey": "00149b99110a310460a8cbf428144fd5796b451ef003",
+          "scriptpubkey_asm": "OP_0 OP_PUSHBYTES_20 9b99110a310460a8cbf428144fd5796b451ef003",
+          "scriptpubkey_type": "v0_p2wpkh",
+          "scriptpubkey_address": "tb1qnwv3zz33q3s23jl59q2yl4teddz3auqr2hqhhl",
+          "value": 958000
+        }
+      ],
+      "size": 234,
+      "weight": 609,
+      "fee": 4000,
+      "status": {
+        "confirmed": true,
+        "block_height": 2207945,
+        "block_hash": "0000014a691693c131e003f49c2a0f4403913422879f9f607ee04942e9e37199",
+        "block_time": 1750425431
       }
-    ],
-    "vout": [
-      {
-        "scriptpubkey": "5120ce30776aae6b27a32a6139067032025071f236cd2ae926e5484bee47ef90498d",
-        "scriptpubkey_asm": "OP_PUSHNUM_1 OP_PUSHBYTES_32 ce30776aae6b27a32a6139067032025071f236cd2ae926e5484bee47ef90498d",
-        "scriptpubkey_type": "v1_p2tr",
-        "scriptpubkey_address": "tb1pecc8w64wdvn6x2np8yr8qvsz2pclydkd9t5jde2gf0hy0musfxxsn23q20",
-        "value": 10000
-      },
-      {
-        "scriptpubkey": "00149b99110a310460a8cbf428144fd5796b451ef003",
-        "scriptpubkey_asm": "OP_0 OP_PUSHBYTES_20 9b99110a310460a8cbf428144fd5796b451ef003",
-        "scriptpubkey_type": "v0_p2wpkh",
-        "scriptpubkey_address": "tb1qnwv3zz33q3s23jl59q2yl4teddz3auqr2hqhhl",
-        "value": 958000
+    },
+    {
+      "txid": "f6a0bb040bb43341c24c3803b87f1959001ab41ddbabbe18b0e7c40bdf901247",
+      "version": 1,
+      "locktime": 0,
+      "vin": [
+        {
+          "txid": "83928822546ca24f5ea3fe2e5927758ea1bd4c65028dccfa7ebd704674865584",
+          "vout": 1,
+          "prevout": {
+            "scriptpubkey": "00149b99110a310460a8cbf428144fd5796b451ef003",
+            "scriptpubkey_asm": "OP_0 OP_PUSHBYTES_20 9b99110a310460a8cbf428144fd5796b451ef003",
+            "scriptpubkey_type": "v0_p2wpkh",
+            "scriptpubkey_address": "tb1qnwv3zz33q3s23jl59q2yl4teddz3auqr2hqhhl",
+            "value": 958000
+          },
+          "scriptsig": "",
+          "scriptsig_asm": "",
+          "witness": [
+            "304402203069dacff86865c79ce098366008f630066e49e028a0980789f443034fd6661602204a3781cadddf7472536934621ad32a7eaa27e74da5712f42139a2ce069888e1401",
+            "032c7236caed0e065f9b4570deeb5e4e917c9f23cb81d797b06e6348cf2c7dfa1a"
+          ],
+          "is_coinbase": false,
+          "sequence": 4294967295
+        }
+      ],
+      "vout": [
+        {
+          "scriptpubkey": "0014c434f1d65acefa7355097fae859e26ad33aa3da3",
+          "scriptpubkey_asm": "OP_0 OP_PUSHBYTES_20 c434f1d65acefa7355097fae859e26ad33aa3da3",
+          "scriptpubkey_type": "v0_p2wpkh",
+          "scriptpubkey_address": "tb1qcs60r4j6ema8x4gf07hgt83x45e650dr97q3qv",
+          "value": 10000
+        },
+        {
+          "scriptpubkey": "00149b99110a310460a8cbf428144fd5796b451ef003",
+          "scriptpubkey_asm": "OP_0 OP_PUSHBYTES_20 9b99110a310460a8cbf428144fd5796b451ef003",
+          "scriptpubkey_type": "v0_p2wpkh",
+          "scriptpubkey_address": "tb1qnwv3zz33q3s23jl59q2yl4teddz3auqr2hqhhl",
+          "value": 944000
+        }
+      ],
+      "size": 222,
+      "weight": 561,
+      "fee": 4000,
+      "status": {
+        "confirmed": true,
+        "block_height": 2219065,
+        "block_hash": "000001359dd53633f93b85245f410d289db8b7db77ffafd5aef620ee2225804b",
+        "block_time": 1750769918
       }
-    ],
-    "size": 234,
-    "weight": 609,
-    "fee": 4000,
-    "status": {
-      "confirmed": true,
-      "block_height": 2207945,
-      "block_hash": "0000014a691693c131e003f49c2a0f4403913422879f9f607ee04942e9e37199",
-      "block_time": 1750425431
     }
-  }
-]
+  ]
+}

--- a/fixtures/k1qypa5tq86fzrl0ez32nh8e0ks4tzzkxnnmn8tdvxk04ahzt70u09dagl0mgs4-transactions.json
+++ b/fixtures/k1qypa5tq86fzrl0ez32nh8e0ks4tzzkxnnmn8tdvxk04ahzt70u09dagl0mgs4-transactions.json
@@ -1,48 +1,50 @@
-[
-  {
-    "txid": "a706e96167c3196733828e03bf60bdae793dd70dfe9f1f8a79711eb3c334c12b",
-    "version": 1,
-    "locktime": 0,
-    "vin": [
-      {
-        "txid": "64d1db7082c5860a4c689f90d59809ab6eb3cad9b36691648c4f1c1ded7ae3e8",
-        "vout": 0,
-        "prevout": {
+{
+  "Singleton": [
+    {
+      "txid": "a706e96167c3196733828e03bf60bdae793dd70dfe9f1f8a79711eb3c334c12b",
+      "version": 1,
+      "locktime": 0,
+      "vin": [
+        {
+          "txid": "64d1db7082c5860a4c689f90d59809ab6eb3cad9b36691648c4f1c1ded7ae3e8",
+          "vout": 0,
+          "prevout": {
+            "scriptpubkey": "76a9148aa387fde9e8659457862f49cdcc20b9cc2022d188ac",
+            "scriptpubkey_asm": "OP_DUP OP_HASH160 OP_PUSHBYTES_20 8aa387fde9e8659457862f49cdcc20b9cc2022d1 OP_EQUALVERIFY OP_CHECKSIG",
+            "scriptpubkey_type": "p2pkh",
+            "scriptpubkey_address": "mtA1SshFsJtD2Di1KBSTmyuD23eBqUekQ3",
+            "value": 10000
+          },
+          "scriptsig": "483045022100fc8a5b42b72b0c654e4dd0b3584ffe3237d017de13396d3d37f576259002bff102205293f0faac9368a2555211ee1cca66f99804d5c0486d7a67ee577becf104bfd4012103da2c07d2443fbf228aa773e5f685562158d39ee675b586b3ebdb897e7f1e56f5",
+          "scriptsig_asm": "OP_PUSHBYTES_72 3045022100fc8a5b42b72b0c654e4dd0b3584ffe3237d017de13396d3d37f576259002bff102205293f0faac9368a2555211ee1cca66f99804d5c0486d7a67ee577becf104bfd401 OP_PUSHBYTES_33 03da2c07d2443fbf228aa773e5f685562158d39ee675b586b3ebdb897e7f1e56f5",
+          "is_coinbase": false,
+          "sequence": 4294967295
+        }
+      ],
+      "vout": [
+        {
           "scriptpubkey": "76a9148aa387fde9e8659457862f49cdcc20b9cc2022d188ac",
           "scriptpubkey_asm": "OP_DUP OP_HASH160 OP_PUSHBYTES_20 8aa387fde9e8659457862f49cdcc20b9cc2022d1 OP_EQUALVERIFY OP_CHECKSIG",
           "scriptpubkey_type": "p2pkh",
           "scriptpubkey_address": "mtA1SshFsJtD2Di1KBSTmyuD23eBqUekQ3",
-          "value": 10000
+          "value": 6000
         },
-        "scriptsig": "483045022100fc8a5b42b72b0c654e4dd0b3584ffe3237d017de13396d3d37f576259002bff102205293f0faac9368a2555211ee1cca66f99804d5c0486d7a67ee577becf104bfd4012103da2c07d2443fbf228aa773e5f685562158d39ee675b586b3ebdb897e7f1e56f5",
-        "scriptsig_asm": "OP_PUSHBYTES_72 3045022100fc8a5b42b72b0c654e4dd0b3584ffe3237d017de13396d3d37f576259002bff102205293f0faac9368a2555211ee1cca66f99804d5c0486d7a67ee577becf104bfd401 OP_PUSHBYTES_33 03da2c07d2443fbf228aa773e5f685562158d39ee675b586b3ebdb897e7f1e56f5",
-        "is_coinbase": false,
-        "sequence": 4294967295
+        {
+          "scriptpubkey": "6a203beb201e710bc93a3c633351b13d6b5b8a2583ec02631832ec16061e9337845f",
+          "scriptpubkey_asm": "OP_RETURN OP_PUSHBYTES_32 3beb201e710bc93a3c633351b13d6b5b8a2583ec02631832ec16061e9337845f",
+          "scriptpubkey_type": "op_return",
+          "value": 0
+        }
+      ],
+      "size": 235,
+      "weight": 940,
+      "fee": 4000,
+      "status": {
+        "confirmed": true,
+        "block_height": 2219084,
+        "block_hash": "000000de7cb3ac20c17f594ec68b71a93fb25886b774de2385af585b7ecc0f99",
+        "block_time": 1750770503
       }
-    ],
-    "vout": [
-      {
-        "scriptpubkey": "76a9148aa387fde9e8659457862f49cdcc20b9cc2022d188ac",
-        "scriptpubkey_asm": "OP_DUP OP_HASH160 OP_PUSHBYTES_20 8aa387fde9e8659457862f49cdcc20b9cc2022d1 OP_EQUALVERIFY OP_CHECKSIG",
-        "scriptpubkey_type": "p2pkh",
-        "scriptpubkey_address": "mtA1SshFsJtD2Di1KBSTmyuD23eBqUekQ3",
-        "value": 6000
-      },
-      {
-        "scriptpubkey": "6a203beb201e710bc93a3c633351b13d6b5b8a2583ec02631832ec16061e9337845f",
-        "scriptpubkey_asm": "OP_RETURN OP_PUSHBYTES_32 3beb201e710bc93a3c633351b13d6b5b8a2583ec02631832ec16061e9337845f",
-        "scriptpubkey_type": "op_return",
-        "value": 0
-      }
-    ],
-    "size": 235,
-    "weight": 940,
-    "fee": 4000,
-    "status": {
-      "confirmed": true,
-      "block_height": 2219084,
-      "block_hash": "000000de7cb3ac20c17f594ec68b71a93fb25886b774de2385af585b7ecc0f99",
-      "block_time": 1750770503
     }
-  }
-]
+  ]
+}

--- a/src/beacon.rs
+++ b/src/beacon.rs
@@ -1,6 +1,7 @@
 use crate::identifier::Network;
 use esploda::bitcoin::address::Address;
 use onlyerror::Error;
+use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::{fmt, str::FromStr};
 
@@ -45,18 +46,18 @@ impl AddressExt for Address {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Beacon {
     id: String,
-    pub(crate) ty: Type,
+    pub(crate) ty: BeaconType,
     pub(crate) descriptor: Address,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum Type {
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Deserialize, Serialize)]
+pub enum BeaconType {
     Singleton,
     Map,
     SparseMerkleTree,
 }
 
-impl FromStr for Type {
+impl FromStr for BeaconType {
     type Err = Error;
 
     fn from_str(ty: &str) -> Result<Self, Self::Err> {
@@ -69,7 +70,7 @@ impl FromStr for Type {
     }
 }
 
-impl fmt::Display for Type {
+impl fmt::Display for BeaconType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Singleton => f.write_str("SingletonBeacon"),
@@ -80,7 +81,7 @@ impl fmt::Display for Type {
 }
 
 impl Beacon {
-    pub(crate) fn new(id: String, ty: Type, descriptor: Address) -> Self {
+    pub(crate) fn new(id: String, ty: BeaconType, descriptor: Address) -> Self {
         Self { id, ty, descriptor }
     }
 


### PR DESCRIPTION
- Added `json-patch` for updates
- Fixed the last two tests
- Removed old unused `Document` methods
- Implemented `CanonicalHash` for `Document`
- Refactored sans-I/O transactions into a `HashMap`
- Added transaction request caching, which replaces the block height check in the spec

TBD:

Add some kind of test utilities to make blockchain traversal nicer to write tests against.