### PR TITLE
Rename Traversal to Resolver

### DIFF
--- a/examples/read_did.rs
+++ b/examples/read_did.rs
@@ -1,10 +1,9 @@
 use anyhow::Result;
-use did_btc1::blockchain::TraversalState;
+use did_btc1::resolver::ResolverState;
 use did_btc1::{Document, ResolutionOptions, document::SidecarData};
 use std::collections::HashMap;
 
 fn main() -> Result<()> {
-    // TODO: Need all of the sidecar data to resolve the given DID (because it has updates).
     let resolution_options = ResolutionOptions {
         sidecar_data: Some(SidecarData {
             blockchain_rpc_uri: Some("https://mutinynet.com/api".into()),
@@ -14,35 +13,34 @@ fn main() -> Result<()> {
     };
 
     let agent = ureq::agent();
-    let did = "did:btc1:k1q5pa5tq86fzrl0ez32nh8e0ks4tzzkxnnmn8tdvxk04ahzt70u09dag02h0cp".parse()?;
+    let did = "did:btc1:k1q5pqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqsx6n2m7".parse()?;
     let mut fsm = Document::read(&did, resolution_options)?;
 
     // Drive the blockchain traversal state machine forward.
-    loop {
-        match fsm.traverse()? {
-            TraversalState::Requests(next_state, requests) => {
+    let document = loop {
+        match fsm.resolve()? {
+            // The state machine delegates blockchain requests to us.
+            ResolverState::Requests(next_state, beacons) => {
                 let mut responses = HashMap::new();
 
-                for (beacon_type, requests) in requests {
+                for (beacon_type, requests) in beacons {
                     for req in requests {
                         let mut resp = agent.run(req)?;
 
-                        let transactions: Vec<_> = resp.body_mut().read_json()?;
-
                         let entry: &mut Vec<_> = responses.entry(beacon_type).or_default();
-                        entry.extend(transactions);
+                        entry.extend(resp.body_mut().read_json::<Vec<_>>()?);
                     }
                 }
 
                 fsm = next_state.process_responses(responses);
             }
 
-            TraversalState::Resolved(document) => {
-                println!("Resolved document: {document:#?}");
-                break;
-            }
+            // And eventually yields a resolved document.
+            ResolverState::Resolved(document) => break document,
         }
-    }
+    };
+
+    println!("Resolved document: {document:#?}");
 
     Ok(())
 }

--- a/src/identifier.rs
+++ b/src/identifier.rs
@@ -335,12 +335,12 @@ pub struct DidComponents {
 
 impl DidComponents {
     /// Create new DID components with validation
-    pub fn new(version: DidVersion, network: Network, id_type: IdType) -> Result<Self, Error> {
-        Ok(Self {
+    pub fn new(version: DidVersion, network: Network, id_type: IdType) -> Self {
+        Self {
             version,
             network,
             id_type,
-        })
+        }
     }
 
     pub fn version(&self) -> DidVersion {
@@ -408,7 +408,7 @@ pub fn parse_did_identifier(did: &str) -> Result<DidComponents, Error> {
     let network = Network::try_from(network_nibble)?;
 
     // Create and validate components
-    DidComponents::new(version.try_into()?, network, id_type)
+    Ok(DidComponents::new(version.try_into()?, network, id_type))
 }
 
 /// Encode DID components into a DID:BTC1 identifier string

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
 pub mod beacon;
-pub mod blockchain;
 pub mod document;
 pub mod error;
 pub mod identifier;
 pub mod key;
+pub mod resolver;
 pub mod verification;
 
 mod canonical_hash;

--- a/src/update.rs
+++ b/src/update.rs
@@ -16,10 +16,6 @@ pub enum Error {
     /// JSON value parse error
     JsonValue(#[from] json_tools::JsonError),
 
-    /// Invalid SHA256 hash
-    #[error("Invalid SHA256 hash: {0}")]
-    InvalidHash(&'static str),
-
     /// Invalid targetVersionId
     InvalidTargetVersionId,
 }
@@ -51,13 +47,15 @@ impl Update {
     pub fn from_json_value(json: Value) -> Result<Self, Error> {
         use json_tools::*;
 
+        // TODO: Can we replace this with serde?
         let source_hash = hash_from_object(&json, "sourceHash")?;
         let target_hash = hash_from_object(&json, "targetHash")?;
         let target_version_id = u64::try_from(int_from_object(&json, "targetVersionId")?)
             .map_err(|_| Error::InvalidTargetVersionId)?
             .try_into()
             .map_err(|_| Error::InvalidTargetVersionId)?;
-        // TODO: Check whether "proof" exists as a key.
+        // TODO: Check whether "proof" and "path" exists as a key.
+        // TODO: Remove these clones
         let proof = serde_json::from_value(json["proof"].clone())?;
         let patch = serde_json::from_value(json["patch"].clone())?;
 
@@ -119,5 +117,3 @@ impl AsRef<Value> for UnsecuredUpdate {
 }
 
 impl CanonicalHash for UnsecuredUpdate {}
-
-pub struct DocumentPatch;


### PR DESCRIPTION
And several other cleanups:

- Renamed `blockchain` module to `resolver`
- The `read_did` example now uses a valid deterministic DID (with no associated SecretKey) with no updates (so no requirement to provide sidecar data)
- Made a few more methods infallible where possible.
- Cleaned up some beacon handling code in the resolver, adding todo's where appropriate
- Removed some dead code like an unused FSM state and replaced the `DocumentPatch` placeholder with `json_patch::Patch`
- Added todo comments to investigate whether we can remove `json_utils` parsing code with `serde`